### PR TITLE
update example app

### DIFF
--- a/example-app/ios/Podfile
+++ b/example-app/ios/Podfile
@@ -1,7 +1,7 @@
 require_relative '../node_modules/react-native/scripts/react_native_pods'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
-platform :ios, '10.0'
+platform :ios, '11.0'
 
 target 'FlybuyExample' do
   config = use_native_modules!

--- a/example-app/src/App.tsx
+++ b/example-app/src/App.tsx
@@ -13,10 +13,15 @@ import Button from './Button';
 import FlyBuy from 'react-native-bildit-flybuy';
 import AppConfig from './AppConfig.json';
 
-const NEW_ORDER_ID = 15942;
+// Add your Flybuy Sandbox Site ID Here
+
+const SITE_ID = 1;
+
+// Defines Customer Information
+
 const CUSTOMER_INFO = {
-  name: 'Lamia Selmane AB',
-  carType: 'Nothing',
+  name: 'React Test',
+  carType: 'Honda',
   carColor: 'Silver',
   licensePlate: 'Nothing',
   phone: '555-555-5555',
@@ -87,13 +92,21 @@ export default function App() {
       });
   };
 
+
+  // "pickupWindow", "OrderState", and "PickupType" are optional fields in the CreateOrder
+  // If you leave out "pickupWindow", the pickup window will be set to ASAP
+
   const createOrder = () => {
+    const pickup_start = new Date();
+    var pickup_end = new Date(pickup_start);
+    pickup_end.setHours(pickup_start.getHours() + 1);
+
     const pickupWindow = {
-      start: new Date().toISOString(),
-      end: new Date('2022-12-02').toISOString(),
+      start: pickup_start.toISOString(),
+      end: pickup_end.toISOString(),
     };
     FlyBuy.Core.Orders.createOrder(
-      NEW_ORDER_ID,
+      SITE_ID,
       partnerId,
       CUSTOMER_INFO,
       pickupWindow,


### PR DESCRIPTION
- Update podfile to 11.0
- Replace `const NEW_ORDER_ID = 15942;` with `const SITE_ID = 1;`. Devs using the example app will need to add their Flybuy site id(Their app auth token would not have access to site 15942) + `NEW_ORDER_ID` could be confusing since it is supposed to be a site id
- Replace pickup window with a more realistic and dynamic time range
- Change customer information 
- Add comments about the optional fields in the create order

Let me know if you would like me to revert anything or make other changes! Thanks!