### PR TITLE
Fix: Missing createdAt Field #47

### DIFF
--- a/android/src/main/java/com/reactnativeflybuy/FlybuyModule.kt
+++ b/android/src/main/java/com/reactnativeflybuy/FlybuyModule.kt
@@ -687,6 +687,7 @@ fun parseOrder(order: Order): WritableMap {
   map.putArray("pickupWindow", pickupWindow)
   map.putString("pickupType", order.pickupType)
   map.putString("etaAt", order.etaAt?.toString())
+  map.putString("createdAt", order.createdAt?.toString())
   map.putString("redemptionCode", order.redemptionCode)
   map.putString("redeemedAt", order.redeemedAt.toString())
   order.customerRatingValue?.let { map.putInt("customerRating", it) }

--- a/ios/Flybuy.swift
+++ b/ios/Flybuy.swift
@@ -593,6 +593,7 @@ class Flybuy: RCTEventEmitter {
             "etaAt": order.etaAt?.description,
             "redemptionCode": order.redemptionCode,
             "redeemedAt": order.redeemedAt?.description,
+            "createdAt": order.createdAt?.description,
             "customerRating": order.customerRating,
             "customerComment": order.customerComment,
             

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,6 +23,7 @@ export interface IOrder {
   redemptionCode?: string;
   customerRating?: string;
   customerComment?: string;
+  createdAt?: string;
 
   siteID: number;
   siteName?: string;


### PR DESCRIPTION
This PR adds the missing `createdAt` attribute to both platforms (iOS/Android) and expose it in `IOrder` TypeScript Interface.