### PR TITLE
Fix bootstrap script

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "prepare": "bob build",
     "release": "release-it --ci",
-    "example": "yarn --cwd example",
-    "pods": "cd example && pod-install --quiet",
+    "example": "yarn --cwd example-app",
+    "pods": "cd example-app && pod-install --quiet",
     "bootstrap": "yarn example && yarn && yarn pods"
   },
   "keywords": [


### PR DESCRIPTION
fix: the `yarn bootstrap` was failing because the it was pointing to the example folder instead of the example-app folder.