### PR TITLE
Enhance PickupConfig, Order and Site types with new properties;

### DIFF
--- a/docusaurus-docs/docs/Types/PickupConfig.md
+++ b/docusaurus-docs/docs/Types/PickupConfig.md
@@ -14,9 +14,11 @@ sidebar_position: 1
   accentTextColor: string;
   askToAskImageURL?: string;
   availablePickupTypes: IPickupTypeConfig[];
+  availableHandoffVehicleLocation?: string;
   customerNameEditingEnabled: boolean;
-  enableCustomerFeedback?: boolean;
+  customerFeedbackEnabled?: boolean;
   id: number;
+  orderProgressStates?: string;
   pickupTypeSelectionEnabled: boolean;
   privacyPolicyURL?: string;
   termsOfServiceURL?: string;

--- a/docusaurus-docs/docs/Types/Site.md
+++ b/docusaurus-docs/docs/Types/Site.md
@@ -27,6 +27,8 @@ sidebar_position: 3
   description?: string | null;
   partnerIdentifier?: string | null;
   pickupConfig?: PickupConfig | null;
+  operationalStatus?: string | null;
+  prearrivalSeconds?: number | null;
 }
 ```
 

--- a/mono/lerna.json
+++ b/mono/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "2.23.2"
+  "version": "2.24.0"
 }

--- a/mono/packages/core/android/src/main/java/com/bilditplatform/rnflybuycore/Decoder.kt
+++ b/mono/packages/core/android/src/main/java/com/bilditplatform/rnflybuycore/Decoder.kt
@@ -200,6 +200,7 @@ fun decodeSite(site: ReadableMap): Site {
   var description: String? = null
   var partnerIdentifier: String? = null
   var operationalStatus: String? = null
+  var prearrivalSeconds: Int? = null
   var pickupConfigId: Int? = null
 
 
@@ -269,6 +270,10 @@ fun decodeSite(site: ReadableMap): Site {
     operationalStatus = site.getString("operationalStatus")
   }
 
+  if (site.hasKey("prearrivalSeconds")) {
+    prearrivalSeconds = site.getInt("prearrivalSeconds")
+  }
+
   if (site.hasKey("pickupConfigId")) {
     pickupConfigId = site.getInt("pickupConfigId")
   }
@@ -293,11 +298,11 @@ fun decodeSite(site: ReadableMap): Site {
     type = type,
     displayName = displayName,
     operationalStatus = operationalStatus,
+    prearrivalSeconds = prearrivalSeconds,
     pickupConfigId = pickupConfigId,
     // TODO: Map this value from API response
     projectAccentColor = null,
     geofence = null,
-    prearrivalSeconds = null,
     projectAccentTextColor = null,
     wrongSiteArrivalRadius = null,
 

--- a/mono/packages/core/android/src/main/java/com/bilditplatform/rnflybuycore/Parser.kt
+++ b/mono/packages/core/android/src/main/java/com/bilditplatform/rnflybuycore/Parser.kt
@@ -50,6 +50,11 @@ fun parseOrder(order: Order): WritableMap {
   map.putString("spotIdentifier", order.spotIdentifier)
   map.putBoolean("spotIdentifierEntryEnabled", order.spotIdentifierEntryEnabled)
   map.putString("spotIdentifierInputType", order.spotIdentifierInputType.toString())
+  map.putString("estimatedReadyAt", order.estimatedReadyAt?.toString())
+  map.putString("partnerIdentifierForCustomer", order.partnerIdentifierForCustomer)
+  map.putString("partnerIdentifierForCrew", order.partnerIdentifierForCrew)
+  map.putString("displayName", order.displayName)
+  map.putString("handoffVehicleLocation", order.handoffVehicleLocation)
 
   return map
 }
@@ -114,14 +119,16 @@ fun parsePickupConfig(pickupConfig: PickupConfig): WritableMap {
   map.putString("accentColor", pickupConfig.projectAccentColor)
   map.putString("accentTextColor", pickupConfig.projectAccentTextColor)
   map.putString("askToAskImageURL", pickupConfig.askToAskImageUrl)
+  map.putString("availableHandoffVehicleLocation", pickupConfig.availableHandoffVehicleLocation)
+  map.putArray("availablePickupTypes", parsePickupTypeConfigs(pickupConfig.availablePickupTypes))
+  map.putBoolean("customerFeedbackEnabled", pickupConfig.customerFeedbackEnabled)
   map.putBoolean("customerNameEditingEnabled", pickupConfig.customerNameEditingEnabled)
-  map.putBoolean("enableCustomerFeedback", pickupConfig.enableCustomerFeedback)
   map.putInt("id", pickupConfig.id)
+  // TODO: find a way to parse orderProgressStates
   map.putBoolean("pickupTypeSelectionEnabled", pickupConfig.pickupTypeSelectionEnabled)
   map.putString("privacyPolicyURL", pickupConfig.privacyPolicyUrl)
   map.putString("termsOfServiceURL", pickupConfig.termsOfServiceUrl)
   map.putString("type", pickupConfig.type)
-  map.putArray("availablePickupTypes", parsePickupTypeConfigs(pickupConfig.availablePickupTypes))
   return map
 }
 
@@ -143,6 +150,8 @@ fun parseSite(site: Site): WritableMap {
   map.putString("description", site.description)
   map.putString("partnerIdentifier", site.partnerIdentifier)
   map.putMap("pickupConfig", parsePickupConfig(site.pickupConfig))
+  map.putString("operationalStatus", site.operationalStatus)
+  map.putInt("prearrivalSeconds", site.prearrivalSeconds)
 
   return map
 }

--- a/mono/packages/core/ios/RnFlybuyCore.mm
+++ b/mono/packages/core/ios/RnFlybuyCore.mm
@@ -563,6 +563,9 @@ RCT_EXPORT_METHOD(placesRetrieve:(NSDictionary *)place
   map[@"description"] = site.description ?: @"";
   map[@"partnerIdentifier"] = site.partnerIdentifier ?: @"";
   map[@"pickupConfig"] = [self parsePickupConfig:site.pickupConfig];
+  map[@"operationalStatus"] = site.operationalStatus ?: @"";
+  map[@"prearrivalSeconds"] = @(site.prearrivalSeconds);
+
   return map;
 }
 
@@ -657,6 +660,12 @@ RCT_EXPORT_METHOD(placesRetrieve:(NSDictionary *)place
         // TODO: check the SDK
         // @"spotIdentifierEntryEnabled": @(order.spotIdentifierEntryEnabled),
         @"spotIdentifierInputType": order.spotIdentifierInputType ?: [NSNull null]
+
+        @"estimatedReadyAt": order.estimatedReadyAt.description ?: [NSNull null],
+        @"partnerIdentifierForCustomer": order.partnerIdentifierForCustomer ?: [NSNull null],
+        @"partnerIdentifierForCrew": order.partnerIdentifierForCrew ?: [NSNull null],
+        @"displayName": order.displayName ?: [NSNull null],
+        @"handoffVehicleLocation": order.handoffVehicleLocation ?: [NSNull null],
     };
 }
 

--- a/mono/packages/core/package.json
+++ b/mono/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-bildit-flybuy-core",
-  "version": "2.23.2",
+  "version": "2.24.0",
   "description": "React Native wrapper for FlyBuy Core SDK",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/mono/packages/core/src/types.ts
+++ b/mono/packages/core/src/types.ts
@@ -42,6 +42,8 @@ export interface ISite {
   instructions?: string | null;
   description?: string | null;
   partnerIdentifier?: string | null;
+  operationalStatus?: string | null;
+  prearrivalSeconds?: number | null;
 }
 
 export interface ICircularRegion {
@@ -52,8 +54,9 @@ export interface ICircularRegion {
 
 export interface IOrder {
   id: number;
+  type?: string;
   state: string;
-  customerState: CustomerState;
+  customerState: string;
   partnerIdentifier?: string;
   pickupWindow?: [string];
   pickupType?: string;
@@ -64,6 +67,11 @@ export interface IOrder {
   customerComment?: string;
   createdAt?: string;
   orderFiredAt?: string;
+  estimatedReadyAt?: string;
+  partnerIdentifierForCustomer?: string;
+  partnerIdentifierForCrew?: string;
+  displayName?: string;
+  handoffVehicleLocation?: string;
 
   siteID: number;
   siteName?: string;
@@ -83,9 +91,10 @@ export interface IOrder {
 
   spotIdentifier?: string;
   spotIdentifierEntryEnabled?: boolean;
-  spotIdentifierInputType?: string;
+  spotIdentifierInputType?: string; 
 }
 
+// @deprecated this enum is deprecated, use string instead
 export enum CustomerState {
   CREATED = 'created',
   EN_ROUTE = 'en_route',
@@ -105,6 +114,7 @@ export enum PlaceType {
   POI = 4,
 }
 
+// @deprecated this enum is deprecated, use string instead
 export enum OrderStateType {
   CREATED = 'created',
   READY = 'ready',
@@ -119,6 +129,7 @@ export enum OrderStateType {
   COMPLETED = 'completed',
 }
 
+// @deprecated this enum is deprecated, use string instead
 export enum PickupType {
   CURBSIDE = 'curbside',
   PICKUP = 'pickup',
@@ -130,8 +141,8 @@ export type CreateOrderWithSitePid = {
   orderPid: string;
   customerInfo: ICustomerInfo;
   pickupWindow?: PickupWindow;
-  orderState?: OrderStateType;
-  pickupType?: PickupType;
+  orderState?: string;
+  pickupType?: string;
 };
 
 export type CreateOrderWithSiteId = {
@@ -139,8 +150,8 @@ export type CreateOrderWithSiteId = {
   pid: string;
   customerInfo: ICustomerInfo;
   pickupWindow?: PickupWindow;
-  orderState?: OrderStateType;
-  pickupType?: PickupType;
+  orderState?: string;
+  pickupType?: string;
 };
 
 export type CreateOrderParamsType = Partial<CreateOrderWithSiteId> &
@@ -181,7 +192,7 @@ export type PlaceSuggestOptions = {
 };
 
 export type PickupMethodOptions = {
-  pickupType: PickupType;
+  pickupType: string;
   customerCarColor?: string;
   customerCarType?: string;
   customerLicensePlate?: string;

--- a/mono/packages/livestatus/package.json
+++ b/mono/packages/livestatus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-bildit-flybuy-livestatus",
-  "version": "2.23.2",
+  "version": "2.24.0",
   "description": "React Native Wrapper for FlyBuy LiveStatus SDK",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/mono/packages/notify/android/src/main/java/com/bilditplatform/rnflybuynotify/Parser.kt
+++ b/mono/packages/notify/android/src/main/java/com/bilditplatform/rnflybuynotify/Parser.kt
@@ -47,6 +47,12 @@ fun parseOrder(order: Order): WritableMap {
   map.putBoolean("spotIdentifierEntryEnabled", order.spotIdentifierEntryEnabled)
   map.putString("spotIdentifierInputType", order.spotIdentifierInputType.toString())
 
+  map.putString("estimatedReadyAt", order.estimatedReadyAt?.toString())
+  map.putString("partnerIdentifierForCustomer", order.partnerIdentifierForCustomer)
+  map.putString("partnerIdentifierForCrew", order.partnerIdentifierForCrew)
+  map.putString("displayName", order.displayName)
+  map.putString("handoffVehicleLocation", order.handoffVehicleLocation)
+
   return map
 }
 
@@ -82,14 +88,16 @@ fun parsePickupConfig(pickupConfig: PickupConfig): WritableMap {
   map.putString("accentColor", pickupConfig.projectAccentColor)
   map.putString("accentTextColor", pickupConfig.projectAccentTextColor)
   map.putString("askToAskImageURL", pickupConfig.askToAskImageUrl)
+  map.putString("availableHandoffVehicleLocation", pickupConfig.availableHandoffVehicleLocation)
+  map.putArray("availablePickupTypes", parsePickupTypeConfigs(pickupConfig.availablePickupTypes))
+  map.putBoolean("customerFeedbackEnabled", pickupConfig.customerFeedbackEnabled)
   map.putBoolean("customerNameEditingEnabled", pickupConfig.customerNameEditingEnabled)
-  map.putBoolean("enableCustomerFeedback", pickupConfig.enableCustomerFeedback)
   map.putInt("id", pickupConfig.id)
+  // TODO: find a way to parse orderProgressStates
   map.putBoolean("pickupTypeSelectionEnabled", pickupConfig.pickupTypeSelectionEnabled)
   map.putString("privacyPolicyURL", pickupConfig.privacyPolicyUrl)
   map.putString("termsOfServiceURL", pickupConfig.termsOfServiceUrl)
   map.putString("type", pickupConfig.type)
-  map.putArray("availablePickupTypes", parsePickupTypeConfigs(pickupConfig.availablePickupTypes))
   return map
 }
 
@@ -111,6 +119,8 @@ fun parseSite(site: Site): WritableMap {
   map.putString("description", site.description)
   map.putString("partnerIdentifier", site.partnerIdentifier)
   map.putMap("pickupConfig", parsePickupConfig(site.pickupConfig))
+  map.putString("operationalStatus", site.operationalStatus)
+  map.putInt("prearrivalSeconds", site.prearrivalSeconds)
 
   return map
 }

--- a/mono/packages/notify/ios/RnFlybuyNotify.mm
+++ b/mono/packages/notify/ios/RnFlybuyNotify.mm
@@ -100,6 +100,8 @@ RCT_EXPORT_METHOD(sync:(BOOL *)force
   map[@"description"] = site.description ?: @"";
   map[@"partnerIdentifier"] = site.partnerIdentifier ?: @"";
   map[@"pickupConfig"] = [self parsePickupConfig:site.pickupConfig];
+  map[@"operationalStatus"] = site.operationalStatus ?: @"";
+  map[@"prearrivalSeconds"] = @(site.prearrivalSeconds);
   return map;
 }
 

--- a/mono/packages/notify/package.json
+++ b/mono/packages/notify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-bildit-flybuy-notify",
-  "version": "2.23.2",
+  "version": "2.24.0",
   "description": "React Native Wrapper for FlyBuy Notify SDK",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",
@@ -82,7 +82,7 @@
     "@types/react": "^18.2.44"
   },
   "dependencies": {
-    "react-native-bildit-flybuy-core": "^2.23.2"
+    "react-native-bildit-flybuy-core": "^2.24.0"
   },
   "peerDependencies": {
     "react": "*",

--- a/mono/packages/pickup/package.json
+++ b/mono/packages/pickup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-bildit-flybuy-pickup",
-  "version": "2.23.2",
+  "version": "2.24.0",
   "description": "React Native Wrapper for FlyBuy Pickup SDK",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/mono/packages/presence/package.json
+++ b/mono/packages/presence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-bildit-flybuy-presence",
-  "version": "2.23.2",
+  "version": "2.24.0",
   "description": "React Native Wrapper for FlyBuy Presence SDK",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",


### PR DESCRIPTION
**New attributes**
Order.estimatedReadyAt
Order.partnerIdentifierForCustomer
Order.customerState should be a string
Order.partnerIdentifierForCrew
Order.displayName
Order.handoffVehicleLocation
Site.operationalStatus
Site.prearrivalSeconds
Site.pickupConfig (and associated classes) - Reference docs for [Android](https://www.radiusnetworks.com/developers/reference/android/sdk/core/com.radiusnetworks.flybuy.sdk.data.pickup_config/-pickup-config/index.html) and [iOS](https://www.radiusnetworks.com/developers/reference/ios/FlyBuy/documentation/flybuy/pickupconfig)

**Some other changes:**
Deprecate/remote the following enums. If they are used anywhere, it should be a string instead. This is because our backend can add to these without SDK changes when they are strings.
CustomerState
OrderStateType
PickupType